### PR TITLE
Improve PhotoSwipe attribution layout on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -215,6 +215,43 @@
     height: auto;
 }
 
+/* Give the PhotoSwipe top bar consistent spacing */
+.pswp__top-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px 8px 10px;
+}
+
+/* Base styling for the Flickr attribution control */
+.pswp__button--flickr-attribution {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
+    font-size: 13px;
+    line-height: 1.25;
+    color: #fff;
+    text-decoration: underline;
+    background-color: rgba(0, 0, 0, 0.35);
+    border-radius: 4px;
+    padding: 6px 12px;
+    margin-right: 8px;
+    white-space: nowrap;
+    transition: background-color 0.2s ease;
+}
+
+.pswp__button--flickr-attribution:hover,
+.pswp__button--flickr-attribution:focus-visible {
+    background-color: rgba(0, 0, 0, 0.6);
+    color: #fff;
+}
+
+.pswp__button--flickr-attribution:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+}
+
 /* Respect notches / dynamic islands */
 .pswp {
     padding-top: env(safe-area-inset-top);
@@ -222,43 +259,44 @@
 }
 
 
-/* Mobile: keep everything on ONE row, ensure "View on Flickr" never truncates */
+/* Mobile: allow a second row so "View on Flickr" can breathe */
 @media (max-width: 768px) {
   .pswp__top-bar {
-    flex-wrap: nowrap;         /* single row */
+    flex-wrap: wrap;
     align-items: center;
-    gap: 6px;
-    height: 48px;              /* a bit tighter */
-    padding: 6px 8px;
+    gap: 8px 10px;
+    padding: 10px;
   }
 
-  /* Let counter yield space; it can shrink/ellipsis if needed */
   .pswp__counter {
     order: 0;
-    margin-right: auto;        /* pushes others right */
-    min-width: 0;              /* allow flex-box to shrink */
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-right: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 1 1 auto;
   }
 
-  /* NEVER truncate attribution; keep it inline */
-  .pswp__button--flickr-attribution {
+  .pswp__button--zoom {
     order: 1;
-    flex: 0 0 auto;            /* do not shrink */
-    min-width: max-content;    /* size to full text */
-    white-space: nowrap;       /* single line, no wrap */
-    overflow: visible;         /* no clipping */
-    text-overflow: clip;
-    margin-right: 6px;         /* small gap before icons */
+    margin-left: auto;
   }
 
-  /* Keep zoom/close visible but compact */
-  .pswp__button--zoom  { order: 2; }
-  .pswp__button--close { order: 3; }
+  .pswp__button--close {
+    order: 2;
+  }
 
-  /* Slightly smaller icons on mobile to buy space */
+  .pswp__button--flickr-attribution {
+    order: 3;
+    flex: 1 0 100%;
+    margin-right: 0;
+    white-space: normal;
+    text-align: center;
+    justify-content: center;
+    padding: 8px 12px;
+  }
+
   .pswp__button svg,
   .pswp__preloader .pswp__icn {
     width: 24px;
@@ -266,7 +304,11 @@
   }
 }
 
-/* On very narrow phones, hide the counter to guarantee space for attribution */
+/* On very narrow phones, keep controls visible but reduce chrome */
 @media (max-width: 420px) {
-  .pswp__counter { display: none; }
+  .pswp__counter {
+    order: 3;
+    width: 100%;
+    text-align: center;
+  }
 }

--- a/assets/js/photoswipe-init.js
+++ b/assets/js/photoswipe-init.js
@@ -183,17 +183,6 @@
                 }
             });
 
-            // Give the top bar a gap after PhotoSwipe mounts
-            lightbox.on('afterInit', () => {
-                const topBar = document.querySelector('.pswp__top-bar');
-                if (topBar) {
-                    topBar.style.alignItems = 'center';
-                    topBar.style.gap = '12px';          // space between buttons/links
-                    topBar.style.paddingRight = '10px'; // a little breathing room at the edge
-                    // topBar.style.height = '60px';    // optional: bump height if things feel tight
-                }
-            });
-
             // Add Flickr attribution button
             lightbox.on('uiRegister', function() {
                 const attributionSettings = getAttributionSettings();
@@ -210,47 +199,7 @@
                     onInit: (el, pswp) => {
                         el.setAttribute('target', '_blank');
                         el.setAttribute('rel', 'noopener noreferrer');
-
-                        // Base (mobile-first)
-                        const applySize = () => {
-                            const isDesktop = window.matchMedia('(min-width: 1024px)').matches;
-
-                            // shared styles
-                            el.style.fontSize = '13px';
-                            el.style.textDecoration = 'underline';
-                            el.style.color = '#fff';
-                            el.style.padding = '6px 10px';
-                            el.style.backgroundColor = 'rgba(0,0,0,0.3)';
-                            el.style.borderRadius = '4px';
-                            el.style.transition = 'background-color 0.2s';
-                            el.style.whiteSpace = 'nowrap';
-                            el.style.marginRight = '12px';
-                            el.style.pointerEvents = 'auto';
-
-                            if (isDesktop) {
-                                // show full text on desktop
-                                el.style.maxWidth = 'none';
-                                el.style.overflow = 'visible';
-                                el.style.textOverflow = 'clip';
-                                el.style.flex = '0 0 auto';
-                            } else {
-                                // keep compact on mobile
-                                el.style.maxWidth = '40vw';
-                                el.style.overflow = 'hidden';
-                                el.style.textOverflow = 'ellipsis';
-                                el.style.flex = '0 1 auto';
-                            }
-                        };
-
-                        applySize();
-                        const onResize = () => applySize();
-                        window.addEventListener('resize', onResize);
-                        pswp.on('destroy', () => window.removeEventListener('resize', onResize));
-
-                        // Hover effect (desktop only, harmless on mobile)
-                        el.addEventListener('mouseenter', () => el.style.backgroundColor = 'rgba(0,0,0,0.6)');
-                        el.addEventListener('mouseleave', () => el.style.backgroundColor = 'rgba(0,0,0,0.3)');
-
+                        el.classList.add('pswp__button--flickr-attribution');
                         updateAttributionUrl(el, pswp);
                         pswp.on('change', () => updateAttributionUrl(el, pswp));
                     }


### PR DESCRIPTION
## Summary
- style the PhotoSwipe toolbar and Flickr attribution control with shared CSS
- allow the toolbar to wrap on mobile so the “View on Flickr” link spans the full width without truncation
- remove inline sizing logic from the PhotoSwipe bootstrapper and rely on the shared styles

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6a669938c8323b88ca10bd0e4bd78