### PR TITLE
Refresh admin settings guidance for supported sources

### DIFF
--- a/includes/admin-settings.php
+++ b/includes/admin-settings.php
@@ -585,7 +585,7 @@ class FlickrJustifiedAdminSettings {
             <div class="notice notice-info">
                 <p>
                     <strong><?php _e('How to use:', 'flickr-justified-block'); ?></strong>
-                    <?php _e('Add the "Flickr Justified" block to any post or page, then paste image URLs (one per line) in the block settings.', 'flickr-justified-block'); ?>
+                    <?php _e('Add the "Flickr Justified" block to any post or page, then paste Flickr photo links, album URLs, or direct image links (one per line) in the block settings.', 'flickr-justified-block'); ?>
                 </p>
             </div>
 
@@ -609,11 +609,12 @@ class FlickrJustifiedAdminSettings {
 
 
             <div class="card" style="margin-top: 20px;">
-                <h2><?php _e('Supported URL Formats', 'flickr-justified-block'); ?></h2>
+                <h2><?php _e('Supported Sources', 'flickr-justified-block'); ?></h2>
                 <ul style="list-style: disc; margin-left: 20px;">
                     <li><strong><?php _e('Flickr Photo Pages:', 'flickr-justified-block'); ?></strong> https://www.flickr.com/photos/username/1234567890/</li>
+                    <li><strong><?php _e('Flickr Albums/Sets:', 'flickr-justified-block'); ?></strong> https://www.flickr.com/photos/username/albums/72177720301234567</li>
                     <li><strong><?php _e('Direct Images:', 'flickr-justified-block'); ?></strong> https://example.com/image.jpg</li>
-                    <li><strong><?php _e('Supported Formats:', 'flickr-justified-block'); ?></strong> JPG, PNG, WebP, AVIF, GIF, SVG</li>
+                    <li><strong><?php _e('Supported File Types:', 'flickr-justified-block'); ?></strong> JPG, PNG, WebP, AVIF, GIF, SVG</li>
                 </ul>
             </div>
         </div>

--- a/readme.md
+++ b/readme.md
@@ -8,100 +8,116 @@ Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Display Flickr photos and other images in a beautiful responsive justified gallery layout with this custom Gutenberg block.
+Create immersive justified photo galleries from Flickr albums or direct image links with a Gutenberg block that includes built-in PhotoSwipe lightbox, album lazy-loading, and powerful responsive controls.
 
 == Description ==
 
-Flickr Justified Block is a powerful WordPress block that lets you create stunning justified galleries from Flickr photos and other images. Simply paste image URLs (one per line) and the block automatically arranges them in a responsive justified gallery layout.
+Flickr Justified Block gives you an easy way to build beautiful, edge-to-edge galleries inside the WordPress block editor. Paste Flickr photo page URLs, entire album links, or any direct image URL—the block takes care of the layout, high-resolution fetching, and responsive behaviour for you.
 
-### Key Features
+Whether you're showcasing a single album or curating images from multiple sources, the block keeps everything fast, accessible, and mobile-friendly. It ships with a tuned PhotoSwipe lightbox (no extra plugins needed), smart row sizing, and optional fixed-height rows for more controlled designs.
 
-- Beautiful justified layout: responsive CSS + JS that works across devices
-- Flickr integration: paste Flickr photo page URLs; fetch high‑res via API
-- Customizable: gap spacing, gallery image size, lightbox max dimensions
-- Responsive controls: per‑breakpoint images‑per‑row configuration
-- Accessibility: focus states, high contrast and reduced motion support
-- Performance: caching, lazy loading, minimal dependencies
-- Editor integration: intuitive block sidebar controls
-- Admin settings: easy API key setup and cache management
+### Highlights
 
-### How to Use
+* **Drop-in gallery block** – Add the "Flickr Justified" block, paste URLs (one per line), and you're done.
+* **Flickr photo & album support** – Works with individual photo URLs _and_ full albums/sets. Albums expand automatically and continue loading as visitors scroll.
+* **Direct image compatibility** – Mix Flickr content with JPG, PNG, WebP, AVIF, GIF, or SVG links hosted anywhere.
+* **Built-in PhotoSwipe lightbox** – Optimized for Retina/4K displays with automatic "View on Flickr" attribution buttons.
+* **Responsive control** – Choose images-per-row per breakpoint in the editor; define default breakpoints and column counts globally in Settings → Flickr Justified.
+* **Row height options** – Use automatic height for perfectly justified rows or switch to a fixed pixel height for uniform stripes.
+* **Viewport guard** – Limit image height relative to the visitor’s screen so tall images never overflow.
+* **Album lazy loading** – Large Flickr sets load page-by-page via the REST API, reducing initial page weight and API calls.
+* **Editor previews & validation** – Each URL is checked in the editor sidebar so you can confirm content before publishing.
+* **Performance-minded** – API responses are cached (duration configurable), images load lazily, and layout adjusts without blocking paints.
+* **Error handling** – Choose to show a friendly message or hide the block entirely when Flickr photos are private or unavailable.
 
-1. Add the "Flickr Justified" block to any post or page
-2. In the block sidebar, paste your image URLs (one per line)
-3. Customize gap, display size, and responsive settings
-4. Publish and enjoy your justified gallery!
+### Requirements & Recommendations
 
-### Supported URL Types
-
-- Flickr Photo Pages: https://www.flickr.com/photos/username/1234567890/ (automatically fetches high‑res versions)
-- Direct Image URLs: Any direct link to JPG, PNG, WebP, AVIF, GIF, or SVG images
-- Mixed Content: Combine both Flickr and direct URLs in the same gallery
-
-### Flickr API Setup
-
-To use Flickr photo page URLs, you'll need a free Flickr API key:
-
-1. Visit Flickr App Garden: https://www.flickr.com/services/apps/create/
-2. Create a new app and get your API key
-3. Go to Settings → Flickr Justified in your WordPress admin and enter your API key
-
-Without an API key, the block will still work with direct image URLs.
+* WordPress 5.0 or newer (block editor required)
+* PHP 7.4 or newer
+* A free Flickr API key (only required if you want to use Flickr photo/albums URLs; direct image URLs work without it)
+* HTTPS recommended when loading external images
 
 == Installation ==
 
-### Automatic Installation
+=== Automatic Installation ===
 
-1. Go to your WordPress admin dashboard
-2. Navigate to Plugins → Add New
-3. Search for "Flickr Justified Block"
-4. Click "Install Now" and then "Activate"
+1. In your WordPress dashboard go to **Plugins → Add New**.
+2. Search for "Flickr Justified Block".
+3. Click **Install Now** and then **Activate**.
 
-### Manual Installation
+=== Manual Installation ===
 
-1. Download the plugin zip file
-2. Go to Plugins → Add New → Upload Plugin
-3. Choose the zip file and click "Install Now"
-4. Activate the plugin
+1. Download the plugin ZIP file.
+2. Go to **Plugins → Add New → Upload Plugin** and select the ZIP file.
+3. Click **Install Now**, then **Activate** the plugin.
 
-### Setup
+== Setup ==
 
-1. (Optional) Set up your Flickr API key via Settings → Flickr Justified for Flickr integration
-2. Create or edit a post/page
-3. Add the "Flickr Justified" block from the Media category
-4. Start adding your image URLs!
+1. (Optional, but recommended) Get a free Flickr API key:
+   * Visit the [Flickr App Garden](https://www.flickr.com/services/apps/create/).
+   * Create an app, copy the API key.
+   * In WordPress, go to **Settings → Flickr Justified**, paste the key, and press **Test API Key** to confirm. The key is encrypted before it’s stored.
+2. Adjust plugin defaults if needed:
+   * **Cache Duration** – Controls how long Flickr responses stay cached.
+   * **Responsive Breakpoints** – Define screen widths and default images per row for each device size.
+   * **Error Handling & Messages** – Decide whether to show a notice when photos are private, and customise the text.
+   * **Attribution Text** – Set the label used for lightbox attribution buttons.
+3. Save changes.
+
+== Creating a Gallery ==
+
+1. Edit any post or page and add the **Flickr Justified** block (Media category).
+2. Paste your image sources into the sidebar field—one URL per line. You can mix:
+   * Flickr photo page URLs
+   * Flickr album/set URLs
+   * Direct links to JPG, PNG, WebP, AVIF, GIF, or SVG files
+3. Adjust the block options as needed:
+   * **Gallery Image Size** – Select the target size for grid thumbnails. The lightbox automatically upgrades to larger sizes when available.
+   * **Grid Gap** – Control spacing between items.
+   * **Row Height Mode** – Switch between auto (perfectly justified rows) or fixed row height.
+   * **Row Height** – Pick a fixed pixel height when using the fixed mode.
+   * **Max Viewport Height** – Keep large images within a percentage of the browser height.
+   * **Single Image Alignment** – Choose how a lone image should align within the block.
+   * **Responsive Settings** – Override images-per-row per breakpoint for this gallery.
+4. Preview the block. Each URL will display a thumbnail or album card inside the editor so you can verify the feed.
+5. Publish. On the front end visitors get a responsive justified layout, PhotoSwipe lightbox, and auto-loading albums.
+
+== Working with Flickr Albums ==
+
+* Paste a Flickr album/set URL just like a photo URL. The plugin fetches the first page of photos automatically.
+* Album galleries load additional pages as the visitor approaches the end of the grid. A loading indicator appears while new rows are fetched.
+* Each image links back to Flickr and opens in the built-in lightbox with attribution.
 
 == Frequently Asked Questions ==
 
 = Do I need a Flickr API key? =
 
-A Flickr API key is only required if you want to use Flickr photo page URLs. The block works perfectly with direct image URLs without any API key. Get a free API key at the Flickr App Garden and add it via Settings → Flickr Justified.
-
-= What image formats are supported? =
-
-The block supports JPG, PNG, WebP, AVIF, GIF, and SVG formats. For Flickr photos, it automatically fetches the best available quality.
+Only if you want to use Flickr photo or album URLs. The block still works with direct image URLs without a key. If you add Flickr content, grab a free key from the Flickr App Garden and add it under **Settings → Flickr Justified**.
 
 = How do I change the number of columns? =
 
-Use the responsive settings in the block sidebar to control images per row at each breakpoint.
+Use the **Responsive Settings** panel in the block sidebar to set images-per-row for different screen sizes. You can also set site-wide defaults and breakpoints under **Settings → Flickr Justified**.
 
-= Can I mix Flickr URLs with direct image URLs? =
+= Can I combine Flickr photos and direct image links? =
 
-Yes. You can combine both Flickr photo page URLs and direct image URLs in the same gallery.
+Yes! Mix and match any supported URLs in the same gallery. Albums can live alongside individual images.
+
+= What happens when a photo is private or missing? =
+
+You control the behaviour in **Settings → Flickr Justified**. Choose to display a custom error message or hide the gallery entirely if Flickr returns a privacy or availability error.
+
+= Does the plugin support lightbox galleries out of the box? =
+
+Absolutely. Every gallery automatically uses the bundled PhotoSwipe lightbox. No additional plugins or scripts are required.
 
 = How does caching work? =
 
-Flickr API responses are cached (default one week) to improve performance and reduce API usage. The cache automatically refreshes when needed.
-
-= Is it mobile‑friendly? =
-
-Absolutely. The justified gallery layout automatically adjusts for optimal viewing on phones, tablets, and desktops.
+Flickr API responses (photo data, album pages, user lookups) are cached in WordPress to reduce API usage and speed up pages. You can change the cache duration in the plugin settings.
 
 == Support ==
 
-For support, feature requests, or bug reports, please visit our GitHub repository or contact us through the WordPress.org support forums.
+For help, feature requests, or bug reports please open an issue on the [GitHub repository](https://github.com/radialmonster/flickr-justified-block) or use the WordPress.org support forums.
 
-== Privacy Policy ==
+== Privacy ==
 
-This plugin may connect to the Flickr API when processing Flickr photo URLs. No personal data is sent to external services except for the photo IDs needed to fetch image information. All API responses are cached locally to minimize external requests.
-
+When you paste Flickr URLs the plugin contacts the Flickr API to retrieve image information. Only photo IDs and your API key (if configured) are sent. Responses are cached locally; no other personal data is transmitted. Direct image URLs are loaded directly from their host without contacting Flickr.


### PR DESCRIPTION
## Summary
- update the settings page helper text so it calls out Flickr photos, albums, and direct image links
- refresh the supported sources card to include album URLs and clarify supported file types

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6f18d2ffc832390fae2fab0596d12