### PR TITLE
Allow PhotoSwipe toolbar to wrap on very narrow screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -259,6 +259,10 @@
 
 /* On very narrow phones, keep controls visible but reduce chrome */
 @media (max-width: 420px) {
+  .pswp__top-bar {
+    flex-wrap: wrap;
+  }
+
   .pswp__counter {
     order: 3;
     width: 100%;


### PR DESCRIPTION
## Summary
- allow the PhotoSwipe top bar to wrap again on viewports under 420px so the counter can move below the buttons
- keep the mobile toolbar button layout intact while preventing controls from being pushed off screen on very small devices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f40bee588323aceec339be9950ed