### PR TITLE
Remove album preview photo count text

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -197,13 +197,6 @@
                             })()),
                             el('div', {
                                 style: {
-                                    fontSize: '14px',
-                                    opacity: '0.7',
-                                    marginBottom: '8px'
-                                }
-                            }, imageData.photo_count + ' ' + __('photos will be displayed', 'flickr-justified-block')),
-                            el('div', {
-                                style: {
                                     fontSize: '12px',
                                     opacity: '0.6',
                                     fontStyle: 'italic'


### PR DESCRIPTION
## Summary
- remove the outdated album preview message that stated how many photos will be displayed in the block editor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83467e5508323a083b4876dfb5eae