### PR TITLE
Prevent lazy-loaded galleries from jumping to the top

### DIFF
--- a/assets/js/justified-init.js
+++ b/assets/js/justified-init.js
@@ -654,7 +654,7 @@
                             const rect = anchorCard.getBoundingClientRect();
                             if (!rect) return;
                             const delta = rect.top - anchorViewportTop;
-                            if (Math.abs(delta) > 1) {
+                            if (delta > 1) {
                                 window.scrollBy(0, delta);
                             }
                         });


### PR DESCRIPTION
## Summary
- avoid applying upward scroll corrections when reinitializing the justified gallery so lazy loading no longer jumps to the top

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8a05ec688832395444d20586b7d51