### PR TITLE
Guard scroll correction when anchor card is visible

### DIFF
--- a/assets/js/justified-init.js
+++ b/assets/js/justified-init.js
@@ -653,8 +653,12 @@
                             if (!anchorCard.isConnected) return;
                             const rect = anchorCard.getBoundingClientRect();
                             if (!rect) return;
+                            const viewportHeight = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight || 0;
+                            if (!viewportHeight) return;
+                            const isAnchorVisible = rect.bottom > 0 && rect.top < viewportHeight;
+                            if (!isAnchorVisible) return;
                             const delta = rect.top - anchorViewportTop;
-                            if (delta > 1) {
+                            if (Math.abs(delta) > 1) {
                                 window.scrollBy(0, delta);
                             }
                         });


### PR DESCRIPTION
## Summary
- ensure scroll correction only fires when the anchor card remains within the viewport
- restore bidirectional adjustment by using the absolute delta when the anchor is visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8beb73d388323b4b9c43a51d842ab