### PR TITLE
Handle Flickr rotation metadata in galleries

### DIFF
--- a/flickr-justified-block.php
+++ b/flickr-justified-block.php
@@ -533,36 +533,47 @@ class FlickrJustifiedBlock {
                     $stats = flickr_justified_get_photo_stats($photo_id);
                 }
 
+                $rotation = 0;
+                if (isset($image_data['_rotation'])) {
+                    $rotation = flickr_justified_normalize_rotation($image_data['_rotation']);
+                } elseif (!empty($image_data['_photo_info'])) {
+                    $rotation = flickr_justified_extract_rotation_from_info($image_data['_photo_info']);
+                }
+
                 if (!empty($image_data)) {
                     $preferred_size = 'large';
                     if (isset($image_data[$preferred_size]) && isset($image_data[$preferred_size]['url'])) {
+                        $size_dimensions = flickr_justified_apply_rotation_to_dimensions($image_data[$preferred_size], $rotation);
                         $gallery_items[] = [
                             'url' => $photo_url,
                             'image_url' => esc_url_raw($image_data[$preferred_size]['url']),
-                            'width' => isset($image_data[$preferred_size]['width']) ? absint($image_data[$preferred_size]['width']) : 0,
-                            'height' => isset($image_data[$preferred_size]['height']) ? absint($image_data[$preferred_size]['height']) : 0,
+                            'width' => isset($size_dimensions['width']) ? absint($size_dimensions['width']) : 0,
+                            'height' => isset($size_dimensions['height']) ? absint($size_dimensions['height']) : 0,
                             'flickr_page' => $photo_url,
                             'is_flickr' => true,
                             'view_count' => isset($stats['views']) ? (int) $stats['views'] : 0,
                             'comment_count' => isset($stats['comments']) ? (int) $stats['comments'] : 0,
                             'favorite_count' => isset($stats['favorites']) ? (int) $stats['favorites'] : 0,
                             'position' => $position_counter++,
+                            'rotation' => $rotation,
                         ];
                     } else {
                         // Fallback: use first available size
                         $first_size = array_keys($image_data)[0] ?? null;
                         if ($first_size && isset($image_data[$first_size]['url'])) {
+                            $size_dimensions = flickr_justified_apply_rotation_to_dimensions($image_data[$first_size], $rotation);
                             $gallery_items[] = [
                                 'url' => $photo_url,
                                 'image_url' => esc_url_raw($image_data[$first_size]['url']),
-                                'width' => isset($image_data[$first_size]['width']) ? absint($image_data[$first_size]['width']) : 0,
-                                'height' => isset($image_data[$first_size]['height']) ? absint($image_data[$first_size]['height']) : 0,
+                                'width' => isset($size_dimensions['width']) ? absint($size_dimensions['width']) : 0,
+                                'height' => isset($size_dimensions['height']) ? absint($size_dimensions['height']) : 0,
                                 'flickr_page' => $photo_url,
                                 'is_flickr' => true,
                                 'view_count' => isset($stats['views']) ? (int) $stats['views'] : 0,
                                 'comment_count' => isset($stats['comments']) ? (int) $stats['comments'] : 0,
                                 'favorite_count' => isset($stats['favorites']) ? (int) $stats['favorites'] : 0,
                                 'position' => $position_counter++,
+                                'rotation' => $rotation,
                             ];
                         }
                     }
@@ -577,6 +588,7 @@ class FlickrJustifiedBlock {
                         'comment_count' => isset($stats['comments']) ? (int) $stats['comments'] : 0,
                         'favorite_count' => isset($stats['favorites']) ? (int) $stats['favorites'] : 0,
                         'position' => $position_counter++,
+                        'rotation' => $rotation,
                     ];
                 }
             } else {

--- a/includes/render.php
+++ b/includes/render.php
@@ -1266,7 +1266,8 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
                 esc_attr($gallery_group),
                 $data_attrs,
                 $attribution_attrs,
-                esc_url($display_src)
+                esc_url($display_src),
+                $img_attr_string
             );
         } else {
             $views = isset($photo['views']) ? (int) $photo['views'] : 0;

--- a/includes/render.php
+++ b/includes/render.php
@@ -307,6 +307,11 @@ function flickr_justified_get_flickr_image_sizes_with_dimensions($page_url, $req
             $result['_stats'] = $stats;
         }
 
+        $rotation = flickr_justified_extract_rotation_from_info($photo_info ?? []);
+        if ($rotation) {
+            $result['_rotation'] = $rotation;
+        }
+
         // Cache the results
         $cache_duration = (int) flickr_justified_get_admin_setting('get_cache_duration', WEEK_IN_SECONDS);
         if ($cache_duration <= 0) {
@@ -345,6 +350,86 @@ function flickr_justified_map_api_sizes_to_requested_with_dims($api_sizes, $requ
     }
 
     return $result;
+}
+
+/**
+ * Normalize a Flickr rotation value to the 0-359 range.
+ *
+ * @param mixed $rotation Raw rotation value returned by the API.
+ * @return int Normalized rotation in degrees.
+ */
+function flickr_justified_normalize_rotation($rotation) {
+    if (!is_numeric($rotation)) {
+        return 0;
+    }
+
+    $normalized = (int) round((float) $rotation);
+    $normalized %= 360;
+
+    if ($normalized < 0) {
+        $normalized += 360;
+    }
+
+    return $normalized;
+}
+
+/**
+ * Determine whether width/height should be swapped for a given rotation.
+ *
+ * @param int $rotation Rotation in degrees.
+ * @return bool
+ */
+function flickr_justified_should_swap_dimensions($rotation) {
+    $rotation = flickr_justified_normalize_rotation($rotation);
+
+    return in_array($rotation, [90, 270], true);
+}
+
+/**
+ * Apply rotation-aware width/height swapping to a dimensions array.
+ *
+ * @param array $dimensions Array with optional width/height keys.
+ * @param int   $rotation   Rotation in degrees.
+ * @return array
+ */
+function flickr_justified_apply_rotation_to_dimensions($dimensions, $rotation) {
+    if (!is_array($dimensions)) {
+        return $dimensions;
+    }
+
+    if (!isset($dimensions['width'], $dimensions['height'])) {
+        return $dimensions;
+    }
+
+    if (!flickr_justified_should_swap_dimensions($rotation)) {
+        return $dimensions;
+    }
+
+    $original_width = (int) $dimensions['width'];
+    $original_height = (int) $dimensions['height'];
+
+    $dimensions['width'] = $original_height;
+    $dimensions['height'] = $original_width;
+
+    return $dimensions;
+}
+
+/**
+ * Extract rotation information from a Flickr photo info response.
+ *
+ * @param array $photo_info Photo information array.
+ * @return int Rotation in degrees (0 when unavailable).
+ */
+function flickr_justified_extract_rotation_from_info($photo_info) {
+    if (!is_array($photo_info) || empty($photo_info)) {
+        return 0;
+    }
+
+    if (isset($photo_info['rotation'])) {
+        return flickr_justified_normalize_rotation($photo_info['rotation']);
+    }
+
+    return 0;
 }
 
 /**
@@ -1026,6 +1111,15 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
                 $stats = $image_data['_stats'];
             }
 
+            $rotation = 0;
+            if (isset($photo['rotation'])) {
+                $rotation = flickr_justified_normalize_rotation($photo['rotation']);
+            } elseif (isset($image_data['_rotation'])) {
+                $rotation = flickr_justified_normalize_rotation($image_data['_rotation']);
+            } elseif (!empty($image_data['_photo_info'])) {
+                $rotation = flickr_justified_extract_rotation_from_info($image_data['_photo_info']);
+            }
+
             $display_src = isset($image_data[$image_size]['url']) ? $image_data[$image_size]['url'] : '';
             $dimensions = isset($image_data[$image_size]) ? $image_data[$image_size] : null;
 
@@ -1042,13 +1136,15 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
             }
 
             $lightbox_src = '';
+            $lightbox_dimensions = null;
             if ($best_lightbox_size && isset($image_data[$best_lightbox_size]['url'])) {
                 $lightbox_src = $image_data[$best_lightbox_size]['url'];
+                $lightbox_dimensions = $image_data[$best_lightbox_size];
             }
 
             if (empty($display_src) && !empty($lightbox_src)) {
                 $display_src = $lightbox_src;
-                $dimensions = isset($image_data[$best_lightbox_size]) ? $image_data[$best_lightbox_size] : null;
+                $dimensions = $lightbox_dimensions;
             }
             if (empty($lightbox_src) && !empty($display_src)) {
                 $lightbox_src = $display_src;
@@ -1083,13 +1179,27 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
             }
 
             $data_attrs = '';
-            $lightbox_dimensions = null;
-            if ($best_lightbox_size && isset($image_data[$best_lightbox_size])) {
-                $lightbox_dimensions = $image_data[$best_lightbox_size];
+            $rotated_display_dimensions = flickr_justified_apply_rotation_to_dimensions($dimensions ?? [], $rotation);
+            $rotated_lightbox_dimensions = flickr_justified_apply_rotation_to_dimensions($lightbox_dimensions ?? [], $rotation);
+
+            $width_attr = null;
+            $height_attr = null;
+            if (isset($rotated_lightbox_dimensions['width'], $rotated_lightbox_dimensions['height']) &&
+                $rotated_lightbox_dimensions['width'] > 0 && $rotated_lightbox_dimensions['height'] > 0) {
+                $width_attr = (int) $rotated_lightbox_dimensions['width'];
+                $height_attr = (int) $rotated_lightbox_dimensions['height'];
+            } elseif (isset($rotated_display_dimensions['width'], $rotated_display_dimensions['height']) &&
+                $rotated_display_dimensions['width'] > 0 && $rotated_display_dimensions['height'] > 0) {
+                $width_attr = (int) $rotated_display_dimensions['width'];
+                $height_attr = (int) $rotated_display_dimensions['height'];
             }
 
-            if ($lightbox_dimensions) {
-                $data_attrs = sprintf(' data-width="%d" data-height="%d"', $lightbox_dimensions['width'], $lightbox_dimensions['height']);
+            if (null !== $width_attr && null !== $height_attr) {
+                $data_attrs = sprintf(' data-width="%d" data-height="%d"', $width_attr, $height_attr);
+            }
+
+            if ($rotation) {
+                $data_attrs .= sprintf(' data-rotation="%d"', (int) $rotation);
             }
 
             $lightbox_class = 'flickr-builtin-lightbox';
@@ -1112,6 +1222,9 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
             $favorites = isset($stats['favorites']) ? (int) $stats['favorites'] : 0;
 
             $card_attributes = ['class="flickr-card"', 'style="position: relative;"'];
+            if ($rotation) {
+                $card_attributes[] = 'data-rotation="' . esc_attr($rotation) . '"';
+            }
             if (null !== $position) {
                 $card_attributes[] = 'data-position="' . esc_attr($position) . '"';
             }
@@ -1119,10 +1232,31 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
             $card_attributes[] = 'data-comments="' . esc_attr($comments) . '"';
             $card_attributes[] = 'data-favorites="' . esc_attr($favorites) . '"';
 
+            if (null !== $width_attr && null !== $height_attr) {
+                $card_attributes[] = 'data-width="' . esc_attr($width_attr) . '"';
+                $card_attributes[] = 'data-height="' . esc_attr($height_attr) . '"';
+            }
+
+            $img_extra_attrs = [];
+            if (null !== $width_attr && null !== $height_attr) {
+                $img_extra_attrs[] = 'data-width="' . esc_attr($width_attr) . '"';
+                $img_extra_attrs[] = 'data-height="' . esc_attr($height_attr) . '"';
+            }
+
+            if ($rotation) {
+                $img_extra_attrs[] = 'data-rotation="' . esc_attr($rotation) . '"';
+                $img_extra_attrs[] = 'style="transform: rotate(' . esc_attr($rotation) . 'deg); transform-origin: center center;"';
+            }
+
+            $img_attr_string = '';
+            if (!empty($img_extra_attrs)) {
+                $img_attr_string = ' ' . implode(' ', $img_extra_attrs);
+            }
+
             $output .= sprintf(
                 '<article %s>
                     <a href="%s" class="%s" %s="%s" %s%s>
-                        <img src="%s" loading="lazy" decoding="async" alt="">
+                        <img src="%s" loading="lazy" decoding="async" alt=""%s>
                     </a>
                 </article>',
                 implode(' ', $card_attributes),


### PR DESCRIPTION
## Summary
- add helpers to normalize Flickr rotation values and adjust stored dimensions when images are rotated
- include rotation metadata in gallery markup and lazy-loading responses so cards carry width/height that match the rotated orientation
- update layout and PhotoSwipe scripts to honor rotation when calculating aspect ratios and rendering lightbox content

## Testing
- php -l includes/render.php
- php -l flickr-justified-block.php

------
https://chatgpt.com/codex/tasks/task_e_68da76e223008323a80a2a0cadf9252d