### PR TITLE
Ensure PhotoSwipe lightbox preserves rotation

### DIFF
--- a/assets/js/photoswipe-init.js
+++ b/assets/js/photoswipe-init.js
@@ -286,6 +286,7 @@
             lightbox.on('contentAppend', ({ content }) => updateContentRotation(content));
             lightbox.on('contentActivate', ({ content }) => updateContentRotation(content));
             lightbox.on('contentUpdate', ({ content }) => updateContentRotation(content));
+            lightbox.on('zoomPanUpdate', ({ content }) => updateContentRotation(content));
 
             // Open the lightbox
             lightbox.init();


### PR DESCRIPTION
## Summary
- reapply rotation styling during PhotoSwipe zoom and pan updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da800fb7b48323b68b1cf5bf2a41a6