### PR TITLE
Preserve loading indicator during gallery relayouts

### DIFF
--- a/assets/js/justified-init.js
+++ b/assets/js/justified-init.js
@@ -276,6 +276,12 @@
 
                 setLoadedCount(grid, allCards.length);
 
+                const loadingIndicator = grid.querySelector(':scope > .flickr-loading-indicator');
+                const shouldPreserveIndicator = !!loadingIndicator && (
+                    loadingIndicator?.dataset?.shouldPersist === 'true' ||
+                    grid._flickrLoading === true
+                );
+
                 const cardsData = allCards.map(card => ({
                     element: card,
                     img: card.querySelector('img'),
@@ -322,6 +328,10 @@
                     });
 
                     grid.appendChild(row);
+                }
+
+                if (loadingIndicator && shouldPreserveIndicator) {
+                    grid.appendChild(loadingIndicator);
                 }
 
                 grid.classList.add('justified-initialized');


### PR DESCRIPTION
## Summary
- ensure the gallery relayout logic remembers any visible lazy-loading indicator
- reattach the indicator after rebuilding rows when loading is active or the indicator is flagged to persist

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da8e2aec408323bbd09dc8c3e13a96