### PR TITLE
Fix PhotoSwipe rotation handling

### DIFF
--- a/assets/js/photoswipe-init.js
+++ b/assets/js/photoswipe-init.js
@@ -389,9 +389,16 @@
                 }
 
                 const rotation = normalizeRotation(content.data?.rotation);
-                const imgEl = content.element.querySelector('img');
-                if (imgEl) {
-                    applyRotationToImageElement(imgEl, rotation);
+                let targetElement = null;
+
+                if (content.element.tagName && content.element.tagName.toLowerCase() === 'img') {
+                    targetElement = content.element;
+                } else {
+                    targetElement = content.element.querySelector('img');
+                }
+
+                if (targetElement) {
+                    applyRotationToImageElement(targetElement, rotation);
                 }
             };
 


### PR DESCRIPTION
## Summary
- ensure PhotoSwipe applies rotation styles when the content element itself is an image
- keep Flickr lightbox images correctly oriented by finding the appropriate DOM target

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db4f5fadf0832394d8ee6e651f4bd2