### PR TITLE
Allow skipping Flickr metadata fetches

### DIFF
--- a/flickr-justified-block.php
+++ b/flickr-justified-block.php
@@ -525,7 +525,7 @@ class FlickrJustifiedBlock {
                     'medium800', 'medium640', 'medium500', 'medium',
                     'small400', 'small320', 'small240',
                 ];
-                $image_data = flickr_justified_get_flickr_image_sizes_with_dimensions($photo_url, $available_sizes);
+                $image_data = flickr_justified_get_flickr_image_sizes_with_dimensions($photo_url, $available_sizes, true);
 
                 $photo_id = flickr_justified_extract_photo_id($photo_url);
                 $stats = [];


### PR DESCRIPTION
## Summary
- add an optional metadata flag to the Flickr image size helper and scope caching by the flag
- only fetch photo metadata when the gallery or REST endpoint requires it

## Testing
- php -l includes/render.php
- php -l flickr-justified-block.php

------
https://chatgpt.com/codex/tasks/task_e_68de7fb6b2008323b0126a406178e952