### PR TITLE
Add missing PHP open tag to cache warmer include

### DIFF
--- a/includes/cache-warmers.php
+++ b/includes/cache-warmers.php
@@ -1,3 +1,5 @@
+<?php
+
 /**
  * Cache warmer integration for Flickr Justified Block.
  *


### PR DESCRIPTION
## Summary
- add the missing opening PHP tag to the cache warmer include to prevent raw source output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec442cde083239d31ac1017f40cc0