### PR TITLE
Ensure Flickr transient registry is purged with cache clears

### DIFF
--- a/flickr-justified-block.php
+++ b/flickr-justified-block.php
@@ -378,7 +378,7 @@ class FlickrJustifiedBlock {
                 return new WP_Error('function_missing', 'Required function not available', ['status' => 500]);
             }
 
-            $available_sizes = ['medium', 'large', 'large1600', 'original'];
+            $available_sizes = flickr_justified_get_available_flickr_sizes();
             $image_data = flickr_justified_get_flickr_image_sizes_with_dimensions($url, $available_sizes);
 
             if (empty($image_data)) {
@@ -530,12 +530,7 @@ class FlickrJustifiedBlock {
                     continue;
                 }
 
-                $available_sizes = [
-                    'original', 'large6k', 'large5k', 'largef', 'large4k', 'large3k',
-                    'large2048', 'large1600', 'large1024', 'large',
-                    'medium800', 'medium640', 'medium500', 'medium',
-                    'small400', 'small320', 'small240',
-                ];
+                $available_sizes = flickr_justified_get_available_flickr_sizes();
                 $image_data = flickr_justified_get_flickr_image_sizes_with_dimensions($photo_url, $available_sizes, true);
 
                 $photo_id = flickr_justified_extract_photo_id($photo_url);

--- a/flickr-justified-block.php
+++ b/flickr-justified-block.php
@@ -436,7 +436,7 @@ class FlickrJustifiedBlock {
         }
 
         // Increment request counter
-        set_transient($rate_limit_key, $current_requests + 1, 60); // 60 seconds
+        flickr_justified_set_transient($rate_limit_key, $current_requests + 1, 60); // 60 seconds
 
         $user_id = $request->get_param('user_id');
         $photoset_id = $request->get_param('photoset_id');

--- a/includes/admin-settings.php
+++ b/includes/admin-settings.php
@@ -710,6 +710,29 @@ class FlickrJustifiedAdminSettings {
                 wp_die(__('Insufficient permissions', 'flickr-justified-block'));
             }
 
+            if (function_exists('flickr_justified_get_transient_registry')) {
+                $registry = flickr_justified_get_transient_registry();
+
+                if (!empty($registry)) {
+                    foreach ($registry as $key => $type) {
+                        if ('site' === $type) {
+                            if (function_exists('delete_site_transient')) {
+                                delete_site_transient($key);
+                            }
+                            continue;
+                        }
+
+                        if (function_exists('delete_transient')) {
+                            delete_transient($key);
+                        }
+                    }
+                }
+
+                if (function_exists('flickr_justified_clear_transient_registry')) {
+                    flickr_justified_clear_transient_registry();
+                }
+            }
+
             // Clear all transients that start with our prefix
             global $wpdb;
             $wpdb->query(

--- a/includes/cache-warmers.php
+++ b/includes/cache-warmers.php
@@ -161,6 +161,9 @@ class FlickrJustifiedCacheWarmer {
 
             if (self::warm_url($url)) {
                 $processed++;
+                if (function_exists('flickr_justified_register_transient_key')) {
+                    self::register_registry_entries_for_url($url);
+                }
                 continue;
             }
 
@@ -270,6 +273,67 @@ class FlickrJustifiedCacheWarmer {
         }
 
         return $success;
+    }
+
+    /**
+     * Register known transient keys for a warmed URL.
+     *
+     * @param string $url Warmed Flickr URL.
+     */
+    private static function register_registry_entries_for_url($url) {
+        if (!is_string($url) || '' === $url) {
+            return;
+        }
+
+        if (function_exists('flickr_justified_is_flickr_photo_url') && flickr_justified_is_flickr_photo_url($url)) {
+            if (!function_exists('flickr_justified_extract_photo_id')) {
+                return;
+            }
+
+            $photo_id = flickr_justified_extract_photo_id($url);
+            if (empty($photo_id)) {
+                return;
+            }
+
+            $available_sizes = [
+                'original', 'large6k', 'large5k', 'largef', 'large4k', 'large3k',
+                'large2048', 'large1600', 'large1024', 'large',
+                'medium800', 'medium640', 'medium500', 'medium',
+                'small400', 'small320', 'small240',
+                'thumbnail100', 'thumbnail150s', 'thumbnail75s',
+            ];
+
+            $key_suffix = md5(implode(',', $available_sizes));
+            flickr_justified_register_transient_key('flickr_justified_dims_' . $photo_id . '_' . $key_suffix . '_1');
+            flickr_justified_register_transient_key('flickr_justified_dims_' . $photo_id . '_' . $key_suffix . '_0');
+            flickr_justified_register_transient_key('flickr_justified_photo_info_' . $photo_id);
+
+            return;
+        }
+
+        if (!function_exists('flickr_justified_parse_set_url')) {
+            return;
+        }
+
+        $set_info = flickr_justified_parse_set_url($url);
+        if (!$set_info || empty($set_info['user_id']) || empty($set_info['photoset_id'])) {
+            return;
+        }
+
+        if (!function_exists('flickr_justified_resolve_user_id')) {
+            return;
+        }
+
+        $resolved_user_id = flickr_justified_resolve_user_id($set_info['user_id']);
+        if (empty($resolved_user_id)) {
+            return;
+        }
+
+        $per_page = 50;
+        $cache_key = 'flickr_justified_set_page_v2_' . md5($resolved_user_id . '_' . $set_info['photoset_id'] . '_1_' . $per_page);
+        flickr_justified_register_transient_key($cache_key);
+        flickr_justified_register_transient_key('flickr_justified_set_full_' . md5($resolved_user_id . '_' . $set_info['photoset_id']));
+        flickr_justified_register_transient_key('flickr_justified_set_info_' . md5($resolved_user_id . '_' . $set_info['photoset_id']));
     }
 
     /**

--- a/includes/cache-warmers.php
+++ b/includes/cache-warmers.php
@@ -189,13 +189,7 @@ class FlickrJustifiedCacheWarmer {
 
         $url = trim($url);
 
-        $available_sizes = [
-            'original', 'large6k', 'large5k', 'largef', 'large4k', 'large3k',
-            'large2048', 'large1600', 'large1024', 'large',
-            'medium800', 'medium640', 'medium500', 'medium',
-            'small400', 'small320', 'small240',
-            'thumbnail100', 'thumbnail150s', 'thumbnail75s',
-        ];
+        $available_sizes = flickr_justified_get_available_flickr_sizes(true);
 
         if (function_exists('flickr_justified_is_flickr_photo_url') && flickr_justified_is_flickr_photo_url($url)) {
             if (!function_exists('flickr_justified_get_flickr_image_sizes_with_dimensions')) {
@@ -295,13 +289,7 @@ class FlickrJustifiedCacheWarmer {
                 return;
             }
 
-            $available_sizes = [
-                'original', 'large6k', 'large5k', 'largef', 'large4k', 'large3k',
-                'large2048', 'large1600', 'large1024', 'large',
-                'medium800', 'medium640', 'medium500', 'medium',
-                'small400', 'small320', 'small240',
-                'thumbnail100', 'thumbnail150s', 'thumbnail75s',
-            ];
+            $available_sizes = flickr_justified_get_available_flickr_sizes(true);
 
             $key_suffix = md5(implode(',', $available_sizes));
             flickr_justified_register_transient_key('flickr_justified_dims_' . $photo_id . '_' . $key_suffix . '_1');

--- a/includes/render.php
+++ b/includes/render.php
@@ -196,10 +196,46 @@ function flickr_justified_get_size_label_map() {
             'small400'    => ['Small 400', 'Medium'],
             'small320'    => ['Small 320', 'Small 400', 'Medium'],
             'small240'    => ['Small', 'Small 320', 'Medium'],
+            'thumbnail100' => ['Thumbnail'],
+            'thumbnail150s' => ['Large Square 150', 'Large Square', 'Square'],
+            'thumbnail75s'  => ['Square 75', 'Square'],
         ];
     }
 
     return $size_mapping;
+}
+
+/**
+ * Retrieve the ordered list of Flickr size identifiers used throughout the plugin.
+ *
+ * @param bool $include_thumbnails When true, include square thumbnail sizes.
+ * @return array<int, string>
+ */
+function flickr_justified_get_available_flickr_sizes($include_thumbnails = false) {
+    static $standard_sizes = null;
+    static $sizes_with_thumbnails = null;
+
+    if (null === $standard_sizes) {
+        $standard_sizes = [
+            'original', 'large6k', 'large5k', 'largef', 'large4k', 'large3k',
+            'large2048', 'large1600', 'large1024', 'large',
+            'medium800', 'medium640', 'medium500', 'medium',
+            'small400', 'small320', 'small240',
+        ];
+    }
+
+    if (!$include_thumbnails) {
+        return $standard_sizes;
+    }
+
+    if (null === $sizes_with_thumbnails) {
+        $sizes_with_thumbnails = array_merge(
+            $standard_sizes,
+            ['thumbnail100', 'thumbnail150s', 'thumbnail75s']
+        );
+    }
+
+    return $sizes_with_thumbnails;
 }
 
 /**
@@ -1267,13 +1303,7 @@ function flickr_justified_render_justified_gallery($photos, $block_id, $gap, $im
         }
 
         if ($is_flickr) {
-            $available_sizes = [
-                'original', 'large6k', 'large5k', 'largef', 'large4k', 'large3k',
-                'large2048', 'large1600', 'large1024', 'large',
-                'medium800', 'medium640', 'medium500', 'medium',
-                'small400', 'small320', 'small240',
-                'thumbnail100', 'thumbnail150s', 'thumbnail75s'
-            ];
+            $available_sizes = flickr_justified_get_available_flickr_sizes(true);
 
             $image_data = flickr_justified_get_flickr_image_sizes_with_dimensions($url, $available_sizes, true);
 


### PR DESCRIPTION
## Summary
- add reusable helpers to register Flickr transients, wrap set_transient calls, and re-register keys when cached data is reused
- update the admin cache clear routine to delete every registered transient, clear the registry, and continue removing legacy rows
- extend the cache warmer to register warmed keys so background refreshes repopulate the registry automatically

## Testing
- php -l includes/render.php
- php -l includes/cache-warmers.php
- php -l includes/admin-settings.php
- php -l flickr-justified-block.php

------
https://chatgpt.com/codex/tasks/task_e_68e66383b7e083239441e53cabdf2513